### PR TITLE
Set a maximum version for django-recaptcha as it introduced breaking changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ------------------
-...
+#. Pin django-recaptcha to a version <4, as the namespace and interface changes
 
 1.0 (2018-03-07)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
-    install_requires=['django-recaptcha'],
+    install_requires=['django-recaptcha<4.0.0'],
     extras_require={
         'testing': testing_extras,
         'docs': documentation_extras,


### PR DESCRIPTION
[`django-recaptcha@4.0.0` renames the package namespace to `django_recaptcha`](https://github.com/torchbox/django-recaptcha/blob/main/CHANGELOG.md#400-2023-11-14), and a [comment on #50 ](https://github.com/springload/wagtail-django-recaptcha/pull/50#pullrequestreview-1738739252) mentions that the interface has changed also, so we will need further changes.