### PR TITLE
Create release for version 2.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-Unreleased
+2.1.1 (2024-01-26)
 ------------------
 #. Added tests for Wagtail 5.2
+#. Update version to replace incorrectly published v2.1
 
 2.1 (2023-10-26)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 
 deps =
     dj32: Django>=3.2,<4.0
@@ -41,3 +42,4 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312

--- a/wagtailcaptcha/__init__.py
+++ b/wagtailcaptcha/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.0"
+__version__ = "2.1.1"


### PR DESCRIPTION
I inadvertently published an older version of the code as version 2.1. That release has been yanked, and now v2.1.1 is the latest