### PR TITLE
Update tox to remove unsupported Django, add more Wagtail, and add django-recaptcha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 # Testing dependencies
 testing_extras = [
     # Required for running the tests
-    "tox>=3.26.0,<3.27",
+    "tox>=4.18.1,<4.19",
     # For coverage and PEP8 linting
     "coverage>=6.5.0,<6.6",
-    "flake8>=5.0.4,<5.1",
+    "flake8>=7.0.0,<7.1",
     "isort>=5.10.1",
     # For test site
     "wagtail>=4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,9 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{38,39,310}-dj{32,41}-wt{41,42,50,51,52}
-    py311-dj41-wt{41,42,50,51,52}
-    py311-dj42-wt{50,51,52}
-    py312-dj42-wt{52}
+    py{38,39,310,311}-dj42-wt{50,51,52,60,61,62}-dr4
+    py{310,311,312}-dj50-wt{52,60,61,62}-dr4
+    py{310,311,312}-dj51-wt{60,61,62}-dr4
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -25,12 +24,17 @@ basepython =
     py312: python3.12
 
 deps =
-    dj32: Django>=3.2,<4.0
-    dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
-    wt41: wagtail>=4.1,<5.0
+    dj50: Django>=5.0,<5.1
+    dj51: Django>=5.1,<5.2
+    wt42: wagtail>=4.2,<5.0
     wt50: wagtail>=5.0,<5.1
     wt51: wagtail>=5.1,<5.2
+    wt52: wagtail>=5.2,<5.3
+    wt60: wagtail>=6.0,<6.1
+    wt61: wagtail>=6.1,<6.2
+    wt62: wagtail>=6.2,<6.3
+    dr4: django_recaptcha>=4.0.0,<5.0.0
 
 commands =
     make lint


### PR DESCRIPTION
We were a few releases behind on Django (5.0+) and Wagtail (6.0+), so we're adding these to the matrix, and also retiring some older out-of-support versions.

Additionally, with the (not-that) recent changes to `django_recaptcha`, we add these to the matrix as a variable, so that if we want to vary that in future, we can.