### PR TITLE
Support/wagtail 72 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/testapp/var/media/
 coverage
 coverage_html_report/
 venv/
+.tox

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ testing_extras = [
     "flake8>=7.0.0,<7.1",
     "isort>=5.10.1",
     # For test site
-    "wagtail>=5.2",
+    "wagtail>=6.3",
 ]
 
 # Documentation dependencies
@@ -56,13 +56,12 @@ setup(
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",
         "Framework :: Wagtail :: 7",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
-    install_requires=["django-recaptcha>=4", "wagtail>=5.2"],
+    install_requires=["django-recaptcha>=4", "wagtail>=6.3"],
     extras_require={
         "testing": testing_extras,
         "docs": documentation_extras,

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,13 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 # Testing dependencies
 testing_extras = [
     # Required for running the tests
-    "tox>=4.18.1,<4.19",
+    "tox>=4.32.0,<5",
     # For coverage and PEP8 linting
-    "coverage>=6.5.0,<6.6",
-    "flake8>=7.0.0,<7.1",
-    "isort>=5.10.1",
+    "coverage>=7.11.3,<7.12",
+    "flake8>=7.3.0,<7.4",
+    "isort>=7.0.0,<8",
     # For test site
-    "wagtail>=6.3",
+    "wagtail>=7.0",
 ]
 
 # Documentation dependencies
@@ -46,11 +46,11 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.1",
@@ -61,7 +61,7 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
-    install_requires=["django-recaptcha>=4", "wagtail>=6.3"],
+    install_requires=["django-recaptcha>=4", "wagtail>=7.0"],
     extras_require={
         "testing": testing_extras,
         "docs": documentation_extras,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ testing_extras = [
     "flake8>=7.0.0,<7.1",
     "isort>=5.10.1",
     # For test site
-    "wagtail>=4.1",
+    "wagtail>=5.2",
 ]
 
 # Documentation dependencies
@@ -46,23 +46,23 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 3",
-        "Framework :: Wagtail :: 4",
         "Framework :: Wagtail :: 5",
+        "Framework :: Wagtail :: 6",
+        "Framework :: Wagtail :: 7",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
-    install_requires=["django-recaptcha>=4"],
+    install_requires=["django-recaptcha>=4", "wagtail>=5.2"],
     extras_require={
         "testing": testing_extras,
         "docs": documentation_extras,

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{39}-dj42-wt{52,63,64,70}-dr4
-    py{310,311,312,313}-dj{51,52}-wt{63,63,70}-dr4
+    py{39}-dj42-wt{63,70,71}-dr4
+    py{310,311,312,313}-dj{51,52}-wt{63,70,71}-dr4
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -25,10 +25,10 @@ basepython =
 deps =
     dj42: Django>=4.2,<4.3
     dj51: Django>=5.1,<5.2
-    wt52: wagtail>=5.2,<5.3
+    dj52: Django>=5.2,<5.3
     wt63: wagtail>=6.3,<6.4
-    wt64: wagtail>=6.4,<6.5
     wt70: wagtail>=7.0,<7.1
+    wt71: wagtail>=7.1,<7.2
     dr4: django_recaptcha>=4.0.0,<5.0.0
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{39}-dj42-wt{63,70,71}-dr4
-    py{310,311,312,313}-dj{51,52}-wt{63,70,71}-dr4
+    py{310,311,312}-dj42-wt{70,72}-dr4
+    py{310,311,312,313}-dj{51,52}-wt{70,72}-dr4
+    py314-dj52-wt{70,72}-dr4
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -16,19 +17,17 @@ allowlist_externals =
     make
 
 basepython =
-    py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
     py313: python3.13
-
+    py314: python3.14
 deps =
     dj42: Django>=4.2,<4.3
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
-    wt63: wagtail>=6.3,<6.4
     wt70: wagtail>=7.0,<7.1
-    wt71: wagtail>=7.1,<7.2
+    wt72: wagtail>=7.2,<7.3
     dr4: django_recaptcha>=4.0.0,<5.0.0
 
 commands =
@@ -37,8 +36,8 @@ commands =
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,8 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{38,39,310,311}-dj42-wt{50,51,52,60,61,62}-dr4
-    py{310,311,312}-dj50-wt{52,60,61,62}-dr4
-    py{310,311,312}-dj51-wt{60,61,62}-dr4
+    py{39}-dj42-wt{52,63,64,70}-dr4
+    py{310,311,312,313}-dj{51,52}-wt{63,63,70}-dr4
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -17,23 +16,19 @@ allowlist_externals =
     make
 
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 
 deps =
     dj42: Django>=4.2,<4.3
-    dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
-    wt42: wagtail>=4.2,<5.0
-    wt50: wagtail>=5.0,<5.1
-    wt51: wagtail>=5.1,<5.2
     wt52: wagtail>=5.2,<5.3
-    wt60: wagtail>=6.0,<6.1
-    wt61: wagtail>=6.1,<6.2
-    wt62: wagtail>=6.2,<6.3
+    wt63: wagtail>=6.3,<6.4
+    wt64: wagtail>=6.4,<6.5
+    wt70: wagtail>=7.0,<7.1
     dr4: django_recaptcha>=4.0.0,<5.0.0
 
 commands =
@@ -42,8 +37,8 @@ commands =
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313


### PR DESCRIPTION
This builds off of https://github.com/wagtail-nest/wagtail-django-recaptcha/pull/66

**Platform and Dependency Updates:**

* Expanded supported Python versions in `.github/workflows/test.yml`, `setup.py`, and `tox.ini` to include 3.10–3.14, and removed support for 3.8 and 3.9. 
* Updated testing dependencies in `setup.py` to use newer versions of `tox`, `coverage`, `flake8`, `isort`, and increased the minimum required Wagtail version to 7.0.

**Framework Compatibility:**

* Revised `setup.py` classifiers to add Django 5.1/5.2 and Wagtail 6/7, removing older versions, and added `wagtail>=7.0` to `install_requires`.
* Updated `tox.ini` test environments to target Django 4.2, 5.1, 5.2 and Wagtail 7.0, 7.2, removing older versions from the matrix.

**CI/CD Workflow Improvements:**

* Upgraded GitHub Actions for checkout and Python setup to use the latest versions (`actions/checkout@v5` and `actions/setup-python@v6`).
* Updated the `gh-actions` Python mapping in `tox.ini` to align with the new supported Python versions.