### PR TITLE
Add Wagtail 7.4 to test matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     ; Django 5.2, supported Wagtail versions (LTS + latest)
     py{310,311,312,313}-dj52-wt{70,73}-dr4
     ; Django 6.0, supported Wagtail versions (Django 6.0 support was added in Wagtail 7.3)
-    py{310,311,312,313,314}-dj60-wt73-dr4
+    py{312,313,314}-dj60-{wt73,wt74}-dr4
 
 [testenv]
 setenv =
@@ -27,8 +27,10 @@ basepython =
 
 deps =
     dj52: Django>=5.2b1,<5.3
+    dj60: Django>=6.0,<6.1
     wt70: wagtail>=7.0,<7.1
     wt73: wagtail>=7.3,<7.4
+    wt74: wagtail>=7.4rc1,<7.5
     dr4: django_recaptcha>=4.0.0,<5.0.0
 
 commands =


### PR DESCRIPTION
Adds Wagtail 7.4 to the tox test matrix (under Django 5.2 and 6.0), and pins django60 to Django>=6.0,<6.1.
Also drops py310/311 from the Django 6.0 matrix since those version combinations aren't supported.

**Note:** The pending test (3.9)–test (3.12) required _Expected_ checks are probably stale branch protection entries, we might need to adjust the branch protection settings.
